### PR TITLE
Support iOS 14

### DIFF
--- a/ios/react-native-google-cast.podspec
+++ b/ios/react-native-google-cast.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'Default' do |ss|
     ss.dependency "#{package['name']}/RNGoogleCast"
-    ss.dependency 'google-cast-sdk', '<= 4.3.0'
+    ss.dependency 'google-cast-sdk', '<= 4.5.0'
   end
 
   s.subspec 'NoBluetooth' do |ss|


### PR DESCRIPTION
Use Google Cast SDK 4.5 instead of 4.3 for iOS 14 support.